### PR TITLE
fixed logout to clear all props

### DIFF
--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -92,6 +92,8 @@ export class UserProvider extends Component {
   };
 
   setFinancesOnRep = (finObj, idx) =>{
+    if (this.state.representatives) {
+
     const representatives = this.state.representatives.map((rep, i) =>{
       if(i === idx){
         return {...rep, ...finObj}
@@ -99,6 +101,7 @@ export class UserProvider extends Component {
       return rep;
     });
     this.setState({ representatives });
+  }
   }
 
   setNews = news => {
@@ -137,6 +140,11 @@ export class UserProvider extends Component {
     TokenService.clearCallbackBeforeExpiry();
     IdleService.unRegisterIdleResets();
     this.setUser({ idle: true });
+    this.setUserState(null)
+    this.setState(null);
+    this.setUserDistrict(null); 
+    this.setRepresentatives(null);
+    this.setNews(null);
   };
 
   fetchRefreshToken = () => {

--- a/src/routes/RepresentativeRoute/RepresentativeRoute.js
+++ b/src/routes/RepresentativeRoute/RepresentativeRoute.js
@@ -5,7 +5,6 @@ import TotalContributions from '../../components/TotalContributions/TotalContrib
 import FinancialContributions from '../../components/FinancialContributions/FinancialContributions';
 import './RepresentativeRoute.scss';
 import Icon from 'react-simple-icons';
-import RepresentativeService from '../../services/representatives-service';
 import MoneySpinner from '../../components/MoneySpinner/Spinner';
 import Elephant from './elephant.png'
 import Donkey from './donkey.png'


### PR DESCRIPTION
just needed to clear ALL the props that are checked in the dashboard during logout so that there is no trace of original user left in props/context at all